### PR TITLE
Enhance CI workflow and project metadata for NuGet packaging and publ…

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -109,6 +109,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # Needed to create GitHub releases
+    concurrency:
+      group: 'publish-${{ github.ref_name }}'
+      cancel-in-progress: true
+
 
     steps:
     - name: Download NuGet package artifact

--- a/src/SlackNetBlockBuilder.csproj
+++ b/src/SlackNetBlockBuilder.csproj
@@ -16,7 +16,7 @@
         <RepositoryUrl>https://github.com/d-carrigg/SlackNetBlockBuilder.git</RepositoryUrl> <!-- Replace with your actual repo URL if different -->
         <RepositoryType>git</RepositoryType>
         <PackageTags>slack;block kit;blocks;builder;SlackNet</PackageTags>
-        <PackageReadmeFile>README.md</PackageReadmeFile> <!-- Assumes README.md is in the root, adjust path relative to csproj if needed -->
+        <PackageReadmeFile>../README.md</PackageReadmeFile> <!-- Assumes README.md is in the root, adjust path relative to csproj if needed -->
 
     </PropertyGroup>
     


### PR DESCRIPTION
This pull request introduces significant updates to the `.NET` GitHub Actions workflow and adds NuGet packaging metadata to the `SlackNetBlockBuilder` project. The changes enhance the CI/CD pipeline by supporting additional triggers, automating NuGet package creation and publishing, and improving metadata for NuGet distribution.

### Workflow Enhancements:
* **Expanded Trigger Support**: Updated `.github/workflows/dotnet.yml` to trigger on `feature/*`, `release/*` branches, and version tags (e.g., `v1.0.0`).
* **NuGet Package Creation and Publishing**: Added steps to pack and upload NuGet packages, only triggered for version tags. Introduced a new `publish` job to publish packages to NuGet and create GitHub releases.
* **Improved CI Steps**: Added comments for clarity, ensured tests run for all triggers, and refined conditional logic for pull request-specific steps. [[1]](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344R33-R34) [[2]](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344R69-R72)

### NuGet Metadata Updates:
* **Enhanced Project Metadata**: Updated `SlackNetBlockBuilder.csproj` with NuGet-specific properties, including version, authors, description, license, repository URL, tags, and README file reference.…ishing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automated packaging and publishing of NuGet packages on tagged releases.
  - Automatic creation of GitHub releases with generated release notes and attached NuGet packages.

- **Chores**
  - Expanded workflow triggers to include feature and release branches, as well as version tags.
  - Enhanced NuGet package metadata with author, description, license, repository info, tags, and readme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->