### PR TITLE
Feature/readme

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -31,9 +31,7 @@ jobs:
       with:
         dotnet-version: 8.0.x
         
-    # Copy README to src directory for packing
-    - name: Copy README for NuGet pack
-      run: cp ${{ github.workspace }}/ReadMe.md ${{ github.workspace }}/src/ReadMe.md
+
 
     # Run tests for all triggers (push, pull_request, tag)
     - name: "Restore/Build/Test"
@@ -92,9 +90,9 @@ jobs:
         # NOTE: using trx_files instead of files due to https://github.com/EnricoMi/publish-unit-test-result-action/issues/424
         trx_files: "${{ github.workspace }}/**/*.trx"
 
-    # ls the src dir to confirm the README.md is there
-    - name: List src directory
-      run: ls -la ${{ github.workspace }}/src
+    # Copy README to src directory for packing
+    - name: Copy README for NuGet pack
+      run: cp ${{ github.workspace }}/ReadMe.md ${{ github.workspace }}/src/ReadMe.md
 
     # Pack step: Run always to ensure no errors in the pack step
     - name: Pack NuGet package

--- a/src/SlackNetBlockBuilder.csproj
+++ b/src/SlackNetBlockBuilder.csproj
@@ -39,5 +39,9 @@
       <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
       <PackageReference Include="SlackNet" Version="0.15.5" />
     </ItemGroup>
-
+    
+    <!--Only include this file if it exists-->
+    <ItemGroup Condition="Exists('ReadMe.md')">
+        <None Include="ReadMe.md" Pack="true" PackagePath="\"/>
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/dotnet.yml` file and the `SlackNetBlockBuilder.csproj` file to improve the build and packaging processes. The key changes involve modifying the workflow to ensure proper handling of the README file during packaging and updating the project file to conditionally include the README in the NuGet package.

### Workflow improvements in `.github/workflows/dotnet.yml`:

* Added blank lines for better readability before the "Restore/Build/Test" step in the workflow configuration.
* Updated the "Copy README for NuGet pack" step to explicitly copy the README file to the `src/` directory with a specific filename (`ReadMe.md`). This ensures consistency in the packaging process.

### Project file updates in `SlackNetBlockBuilder.csproj`:

* Added a new `ItemGroup` that conditionally includes the `ReadMe.md` file in the NuGet package only if the file exists. This prevents packaging errors when the file is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow to always copy the README file into the source directory with the correct filename.
	- Adjusted packaging settings to include the README file only if it exists, preventing packaging errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->