### PR TITLE
Update CI workflow: enhance NuGet packaging and increase coverage ret…

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -32,13 +32,6 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
-        
-
-    - name: Restore Dependencies
-      run: dotnet restore
-      
-    - name: Build Solution
-      run: dotnet build --configuration Release --no-restore --verbosity minimal
 
     # Run tests for all triggers (push, pull_request, tag)
     - name: "Restore/Build/Test"
@@ -63,7 +56,7 @@ jobs:
       with:
         name: coverage
         path: ${{ github.workspace }}/Cobertura.xml
-        retention-days: 5
+        retention-days: 14
 
     - name: Publish Code Coverage Report
       uses: irongut/CodeCoverageSummary@v1.3.0
@@ -106,11 +99,13 @@ jobs:
     # Pack step: Run always to ensure no errors in the pack step
     - name: Pack NuGet package
       run: dotnet pack --configuration Release --no-build --output ./artifacts
+      working-directory: ${{ github.workspace }}
 
     # Upload Package Artifact: Only run for tags
     - name: Upload NuGet Package artifact
       if: startsWith(github.ref, 'refs/tags/v')
       uses: actions/upload-artifact@v4
+      working-directory: ${{ github.workspace }}
       with:
         name: nugetPackage
         path: ./artifacts/*.nupkg
@@ -131,9 +126,11 @@ jobs:
     steps:
     - name: Download NuGet package artifact
       uses: actions/download-artifact@v4
+      working-directory: ${{ github.workspace }}
       with:
         name: nugetPackage
         path: ./artifacts
+        
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
@@ -142,14 +139,17 @@ jobs:
 
     - name: Publish to NuGet
       run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+      working-directory: ${{ github.workspace }}
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
+      working-directory: ${{ github.workspace }}
       with:
         files: ./artifacts/*.nupkg
         # The release name will be the tag name (e.g., v1.0.0)
         # The body can be customized, here it's empty by default
         # Set generate_release_notes: true to auto-generate notes based on commits since last tag
         generate_release_notes: true
+        

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -98,7 +98,7 @@ jobs:
 
     # Pack step: Run always to ensure no errors in the pack step
     - name: Pack NuGet package
-      run: dotnet pack --configuration Release --no-build --output ./artifacts
+      run: dotnet pack --configuration Release --no-build --output ${{ github.workspace }}/artifacts
 
     # Upload Package Artifact: Only run for tags
     - name: Upload NuGet Package artifact
@@ -106,7 +106,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: nugetPackage
-        path: artifacts/*.nupkg
+        path: ${{ github.workspace }}/artifacts/*.nupkg
         retention-days: 1 # Keep artifact only for a short time
 
   publish:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -99,7 +99,6 @@ jobs:
     # Pack step: Run always to ensure no errors in the pack step
     - name: Pack NuGet package
       run: dotnet pack --configuration Release --no-build --output ./artifacts
-      working-directory: ${{ github.workspace }}
 
     # Upload Package Artifact: Only run for tags
     - name: Upload NuGet Package artifact

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -105,10 +105,9 @@ jobs:
     - name: Upload NuGet Package artifact
       if: startsWith(github.ref, 'refs/tags/v')
       uses: actions/upload-artifact@v4
-      working-directory: ${{ github.workspace }}
       with:
         name: nugetPackage
-        path: ./artifacts/*.nupkg
+        path: ${{ github.workspace }}/artifacts/*.nupkg
         retention-days: 1 # Keep artifact only for a short time
 
   publish:
@@ -126,10 +125,9 @@ jobs:
     steps:
     - name: Download NuGet package artifact
       uses: actions/download-artifact@v4
-      working-directory: ${{ github.workspace }}
       with:
         name: nugetPackage
-        path: ./artifacts
+        path: ${{ github.workspace }}/artifacts
         
 
     - name: Setup .NET
@@ -145,9 +143,8 @@ jobs:
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
-      working-directory: ${{ github.workspace }}
       with:
-        files: ./artifacts/*.nupkg
+        files: ${{ github.workspace }}/artifacts/*.nupkg
         # The release name will be the tag name (e.g., v1.0.0)
         # The body can be customized, here it's empty by default
         # Set generate_release_notes: true to auto-generate notes based on commits since last tag

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -106,7 +106,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: nugetPackage
-        path: ${{ github.workspace }}/artifacts/*.nupkg
+        path: artifacts/*.nupkg
         retention-days: 1 # Keep artifact only for a short time
 
   publish:


### PR DESCRIPTION
This pull request updates the `.github/workflows/dotnet.yml` file to streamline the workflow, improve maintainability, and enhance artifact handling. The key changes include consolidating build and test steps, extending artifact retention, and adding `working-directory` specifications for better clarity and consistency.

### Workflow simplification:
* Consolidated the "Restore Dependencies" and "Build Solution" steps into a single "Restore/Build/Test" step that runs `dotnet test` with coverage collection.

### Artifact handling improvements:
* Extended the retention period for uploaded artifacts from 5 days to 14 days to preserve code coverage reports longer.
* Added `working-directory: ${{ github.workspace }}` to multiple steps (`Pack NuGet package`, `Upload NuGet Package artifact`, `Download NuGet package artifact`, `Publish to NuGet`, and `Create GitHub Release`) for better directory management and consistency. [[1]](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344R102-R108) [[2]](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344R129-R155)